### PR TITLE
Add real Canvas LMS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ Navigate to [http://localhost:3000](http://localhost:3000) to see the applicatio
 6. **Customize settings** in the settings tab to adjust display preferences
 7. **Export your data** to save your progress or share with others
 
+### Importing from Canvas LMS
+
+1. Choose **Import from LMS** in the toolbar or settings.
+2. Select **Kent Denver School** or choose **Custom** and enter your Canvas URL.
+3. Follow these steps to create a Canvas access token:
+   1. Open **Account &gt; Settings** in Canvas.
+   2. Scroll to **Approved Integrations** and click **New Access Token**.
+   3. Give the token a name and expiration date.
+   4. Copy the generated token.
+4. Paste the token in the dialog and click **Import**.
+
 ## 📊 Grade Calculation Logic
 
 The application uses the following formula to calculate the required score on a final exam:

--- a/app/api/lms/[provider]/route.ts
+++ b/app/api/lms/[provider]/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server"
+import type { GradeClass, Assignment } from "@/types/grade-calculator"
+
+function mapAssignment(a: any): Assignment {
+  return {
+    id: String(a.id),
+    name: a.name,
+    score: a.score ?? 0,
+    totalPoints: a.points_possible ?? 100,
+    weight: 0,
+    date: a.due_at ? a.due_at.split("T")[0] : undefined
+  }
+}
+
+function mapClass(course: any, assignments: any[]): GradeClass {
+  return {
+    id: String(course.id),
+    name: course.name,
+    current: course.enrollments?.[0]?.computed_current_score ?? 0,
+    weight: 100,
+    target: "A",
+    color: "bg-blue-500",
+    credits: course.credits,
+    assignments: assignments.map(mapAssignment)
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { provider: string } }
+) {
+  try {
+    const { provider } = params
+    if (provider !== "canvas") {
+      return NextResponse.json({ error: "Unsupported provider" }, { status: 400 })
+    }
+
+    const body = await req.json().catch(() => ({}))
+    const token = body.token as string | undefined
+    const baseUrl = (body.url as string | undefined)?.replace(/\/$/, "")
+    if (!token || !baseUrl) {
+      return NextResponse.json({ error: "Missing token or url" }, { status: 400 })
+    }
+
+    const headers = { Authorization: `Bearer ${token}` }
+    const coursesRes = await fetch(
+      `${baseUrl}/api/v1/courses?per_page=50&include[]=total_scores&enrollment_state=active`,
+      { headers }
+    )
+    if (!coursesRes.ok) {
+      return NextResponse.json({ error: "Failed to fetch courses" }, { status: coursesRes.status })
+    }
+    const courses = await coursesRes.json()
+
+    const classes: GradeClass[] = []
+    for (const course of courses) {
+      const assignmentsRes = await fetch(
+        `${baseUrl}/api/v1/courses/${course.id}/assignments?per_page=50`,
+        { headers }
+      )
+      const assignments = assignmentsRes.ok ? await assignmentsRes.json() : []
+      classes.push(mapClass(course, assignments))
+    }
+
+    return NextResponse.json({ classes })
+  } catch (err) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 })
+  }
+}

--- a/components/grade-calculator.tsx
+++ b/components/grade-calculator.tsx
@@ -58,6 +58,7 @@ import EnhancedWhatIf from "@/components/enhanced-what-if"
 import GradeStatistics from "@/components/grade-statistics"
 import { ExportDialog } from "@/components/export-dialog"
 import { ShareDialog } from "@/components/share-dialog"
+import { LmsImportDialog } from "@/components/lms-import-dialog"
 import { MobileOptimizations, TouchOptimizations } from "@/components/mobile-optimizations"
 import { useLocalStorage } from "@/hooks/use-local-storage"
 
@@ -234,6 +235,28 @@ export default function GradeCalculator() {
   const generateId = () => {
     return Math.random().toString(36).substring(2, 9)
   }
+
+  // Map data returned from the LMS API into the internal class format
+  const mapLmsClass = (cls: any): GradeClass => ({
+    id: generateId(),
+    name: cls.name || "Class",
+    current: cls.current ?? cls.currentGrade ?? 0,
+    weight: cls.weight ?? 100,
+    target: cls.target ?? "A",
+    color:
+      cls.color || colorOptions[Math.floor(Math.random() * colorOptions.length)].value,
+    credits: cls.credits,
+    assignments: Array.isArray(cls.assignments)
+      ? cls.assignments.map((a: any) => ({
+          id: generateId(),
+          name: a.name || "Assignment",
+          score: a.score ?? 0,
+          totalPoints: a.totalPoints ?? 100,
+          weight: a.weight ?? 0,
+          date: a.date || a.due,
+        }))
+      : [],
+  })
 
   const formatGrade = (grade: number): string => {
     return grade.toFixed(settings.showDecimalPlaces)
@@ -522,6 +545,11 @@ export default function GradeCalculator() {
 
     // Reset the input value so the same file can be imported again if needed
     event.target.value = ""
+  }
+
+  const importFromLms = (lmsClasses: any[]) => {
+    const mapped = lmsClasses.map(mapLmsClass)
+    setClasses([...classes, ...mapped])
   }
 
   const resetData = () => {
@@ -954,6 +982,9 @@ export default function GradeCalculator() {
                   Share
                 </Button>
               }
+            />
+            <LmsImportDialog
+              onImport={importFromLms}
             />
 
             <Button
@@ -1760,6 +1791,7 @@ export default function GradeCalculator() {
                     </Button>
                   }
                 />
+                <LmsImportDialog onImport={importFromLms} />
 
                 <Button
                   variant="outline"

--- a/components/lms-import-dialog.tsx
+++ b/components/lms-import-dialog.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { CloudDownload } from "lucide-react"
+import type { GradeClass } from "@/types/grade-calculator"
+import { useToast } from "@/hooks/use-toast"
+
+interface LmsImportDialogProps {
+  onImport: (classes: GradeClass[]) => void
+  trigger?: React.ReactNode
+}
+
+export function LmsImportDialog({ onImport, trigger }: LmsImportDialogProps) {
+  const { toast } = useToast()
+  const [open, setOpen] = useState(false)
+  const [provider, setProvider] = useState("canvas")
+  const [school, setSchool] = useState("kent")
+  const [customUrl, setCustomUrl] = useState("")
+  const [token, setToken] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const handleImport = async () => {
+    try {
+      setLoading(true)
+      const url =
+        school === "kent"
+          ? "https://kentdenver.instructure.com"
+          : customUrl
+      const res = await fetch(`/api/lms/${provider}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, url }),
+      })
+      if (!res.ok) throw new Error("Request failed")
+      const data = await res.json()
+      if (Array.isArray(data.classes)) {
+        onImport(data.classes as GradeClass[])
+        toast({
+          title: "Import successful",
+          description: "Data imported from your LMS.",
+        })
+        setOpen(false)
+      } else {
+        throw new Error("Invalid response")
+      }
+    } catch (err) {
+      toast({
+        title: "Import failed",
+        description: "Unable to import data from LMS.",
+        variant: "destructive",
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger || (
+          <Button variant="outline" size="sm" className="hidden sm:flex">
+            <CloudDownload className="w-4 h-4 mr-1" />
+            Import from LMS
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Import from LMS</DialogTitle>
+          <DialogDescription>
+            Connect to your learning management system and import your classes.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4 space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="provider">Provider</Label>
+            <Select value={provider} onValueChange={setProvider}>
+              <SelectTrigger id="provider">
+                <SelectValue placeholder="Select a provider" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="canvas">Canvas</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="school">School</Label>
+            <Select value={school} onValueChange={setSchool}>
+              <SelectTrigger id="school">
+                <SelectValue placeholder="Select your school" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="kent">Kent Denver School</SelectItem>
+                <SelectItem value="custom">Custom...</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {school === "custom" && (
+            <div className="space-y-2">
+              <Label htmlFor="canvas-url">Canvas URL</Label>
+              <Input
+                id="canvas-url"
+                placeholder="https://your-school.instructure.com"
+                value={customUrl}
+                onChange={e => setCustomUrl(e.target.value)}
+              />
+            </div>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="token">API Token</Label>
+            <Input id="token" value={token} onChange={e => setToken(e.target.value)} />
+            <p className="text-sm text-muted-foreground">How to create a Canvas token:</p>
+            <ol className="list-decimal pl-5 text-sm text-muted-foreground space-y-1">
+              <li>Log in to Canvas and open <strong>Account &gt; Settings</strong>.</li>
+              <li>Scroll to <strong>Approved Integrations</strong>.</li>
+              <li>Click <strong>New Access Token</strong> and give it a purpose.</li>
+              <li>Copy the generated token and paste it here.</li>
+            </ol>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleImport} disabled={loading}>
+            Import
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,7 +9,8 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
-  output: 'export',
+  // Use the default output so API routes work on Cloudflare Pages
+  output: 'standalone',
   reactStrictMode: true,
   compress: true,
   experimental: {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,4 +2,4 @@ name = "final-exam-grade-calculator"
 compatibility_date = "2023-06-01"
 
 # Configuration for Cloudflare Pages
-pages_build_output_dir = "out"
+pages_build_output_dir = ".vercel/output"


### PR DESCRIPTION
## Summary
- connect to Canvas via API in `/api/lms/[provider]`
- expand LMS import dialog with school and custom URL options
- document Canvas token process in README
- remove static export configuration so API routes work
- update Cloudflare output directory

## Testing
- `npm run lint` *(fails: interactive ESLint prompt)*
- `npm test` *(fails: missing script)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to import grade data directly from Canvas LMS, including a new import dialog and step-by-step UI for connecting your Canvas account.
- **Documentation**
  - Updated usage instructions with a detailed guide for importing grades from Canvas LMS.
- **Chores**
  - Updated deployment and build configurations to support API routes and adjust build output directories for Cloudflare Pages compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->