### PR TITLE
Add Canvas LMS import

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ Navigate to [http://localhost:3000](http://localhost:3000) to see the applicatio
 6. **Customize settings** in the settings tab to adjust display preferences
 7. **Export your data** to save your progress or share with others
 
+### Importing from Canvas LMS
+
+1. Open the **Import from LMS** dialog in the toolbar.
+2. Select **Kent Denver School** or choose **Custom Canvas URL** and enter your school's Canvas domain.
+3. Generate an access token in Canvas:
+   - Log in to Canvas and click **Account** in the sidebar.
+   - Choose **Settings** and scroll to **Approved Integrations**.
+   - Click **New Access Token**, give it a name, and create the token.
+   - Copy the token value.
+4. Paste the token into the dialog and start the import.
+5. Your Canvas courses and assignments will appear in the calculator.
+
 ## 📊 Grade Calculation Logic
 
 The application uses the following formula to calculate the required score on a final exam:

--- a/app/api/lms/[provider]/route.ts
+++ b/app/api/lms/[provider]/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server"
+import type { GradeClass, Assignment } from "@/types/grade-calculator"
+
+export const runtime = "edge"
+
+async function fetchJson(url: string, token: string) {
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error("Request failed")
+  return res.json()
+}
+
+function mapAssignment(a: any): Assignment {
+  return {
+    id: String(a.id),
+    name: a.name || "Assignment",
+    score: a.score ?? a.submission?.score ?? 0,
+    totalPoints: a.totalPoints ?? a.points_possible ?? 100,
+    weight: a.weight ?? 0,
+    date: a.date || a.due_at,
+  }
+}
+
+function mapClass(course: any, assignments: any[]): GradeClass {
+  const score = course.enrollments?.[0]?.computed_current_score ?? 0
+  return {
+    id: String(course.id),
+    name: course.name || "Course",
+    current: typeof score === "number" ? score : 0,
+    weight: 100,
+    target: "A",
+    color: "bg-blue-500",
+    credits: course.credits || course.credit_hours,
+    assignments: assignments.map(mapAssignment),
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { provider: string } },
+) {
+  try {
+    const { provider } = params
+    const body = await req.json().catch(() => ({}))
+    const token = body.token
+    const baseUrl = (body.baseUrl as string | undefined)?.replace(/\/$/, "")
+
+    if (provider !== "canvas" || !token || !baseUrl) {
+      return NextResponse.json(
+        { error: "Missing Canvas token or URL" },
+        { status: 400 },
+      )
+    }
+
+    const courses = await fetchJson(
+      `${baseUrl}/api/v1/courses?enrollment_state=active`,
+      token,
+    )
+
+    const classes: GradeClass[] = []
+
+    for (const course of courses) {
+      const assignmentsData = await fetchJson(
+        `${baseUrl}/api/v1/courses/${course.id}/assignments?per_page=100`,
+        token,
+      ).catch(() => [])
+      classes.push(mapClass(course, assignmentsData))
+    }
+
+    return NextResponse.json({ classes })
+  } catch (err) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 })
+  }
+}

--- a/components/grade-calculator.tsx
+++ b/components/grade-calculator.tsx
@@ -58,6 +58,7 @@ import EnhancedWhatIf from "@/components/enhanced-what-if"
 import GradeStatistics from "@/components/grade-statistics"
 import { ExportDialog } from "@/components/export-dialog"
 import { ShareDialog } from "@/components/share-dialog"
+import { LmsImportDialog } from "@/components/lms-import-dialog"
 import { MobileOptimizations, TouchOptimizations } from "@/components/mobile-optimizations"
 import { useLocalStorage } from "@/hooks/use-local-storage"
 
@@ -234,6 +235,28 @@ export default function GradeCalculator() {
   const generateId = () => {
     return Math.random().toString(36).substring(2, 9)
   }
+
+  // Map data returned from the LMS API into the internal class format
+  const mapLmsClass = (cls: any): GradeClass => ({
+    id: generateId(),
+    name: cls.name || "Class",
+    current: cls.current ?? cls.currentGrade ?? 0,
+    weight: cls.weight ?? 100,
+    target: cls.target ?? "A",
+    color:
+      cls.color || colorOptions[Math.floor(Math.random() * colorOptions.length)].value,
+    credits: cls.credits,
+    assignments: Array.isArray(cls.assignments)
+      ? cls.assignments.map((a: any) => ({
+          id: generateId(),
+          name: a.name || "Assignment",
+          score: a.score ?? 0,
+          totalPoints: a.totalPoints ?? 100,
+          weight: a.weight ?? 0,
+          date: a.date || a.due,
+        }))
+      : [],
+  })
 
   const formatGrade = (grade: number): string => {
     return grade.toFixed(settings.showDecimalPlaces)
@@ -522,6 +545,11 @@ export default function GradeCalculator() {
 
     // Reset the input value so the same file can be imported again if needed
     event.target.value = ""
+  }
+
+  const importFromLms = (lmsClasses: any[]) => {
+    const mapped = lmsClasses.map(mapLmsClass)
+    setClasses([...classes, ...mapped])
   }
 
   const resetData = () => {
@@ -954,6 +982,9 @@ export default function GradeCalculator() {
                   Share
                 </Button>
               }
+            />
+            <LmsImportDialog
+              onImport={importFromLms}
             />
 
             <Button
@@ -1760,6 +1791,7 @@ export default function GradeCalculator() {
                     </Button>
                   }
                 />
+                <LmsImportDialog onImport={importFromLms} />
 
                 <Button
                   variant="outline"

--- a/components/lms-import-dialog.tsx
+++ b/components/lms-import-dialog.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { CloudDownload } from "lucide-react"
+import type { GradeClass } from "@/types/grade-calculator"
+import { useToast } from "@/hooks/use-toast"
+
+interface LmsImportDialogProps {
+  onImport: (classes: GradeClass[]) => void
+  trigger?: React.ReactNode
+}
+
+export function LmsImportDialog({ onImport, trigger }: LmsImportDialogProps) {
+  const { toast } = useToast()
+  const [open, setOpen] = useState(false)
+  const [school, setSchool] = useState("kent")
+  const [customUrl, setCustomUrl] = useState("")
+  const [token, setToken] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const handleImport = async () => {
+    try {
+      setLoading(true)
+      const baseUrl =
+        school === "kent"
+          ? "https://kentdenver.instructure.com"
+          : customUrl
+      const res = await fetch(`/api/lms/canvas`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, baseUrl }),
+      })
+      if (!res.ok) throw new Error("Request failed")
+      const data = await res.json()
+      if (Array.isArray(data.classes)) {
+        onImport(data.classes as GradeClass[])
+        toast({
+          title: "Import successful",
+          description: "Data imported from your LMS.",
+        })
+        setOpen(false)
+      } else {
+        throw new Error("Invalid response")
+      }
+    } catch (err) {
+      toast({
+        title: "Import failed",
+        description: "Unable to import data from LMS.",
+        variant: "destructive",
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger || (
+          <Button variant="outline" size="sm" className="hidden sm:flex">
+            <CloudDownload className="w-4 h-4 mr-1" />
+            Import from LMS
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Import from LMS</DialogTitle>
+          <DialogDescription>
+            Connect to your learning management system and import your classes.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4 space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="school">School</Label>
+            <Select value={school} onValueChange={setSchool}>
+              <SelectTrigger id="school">
+                <SelectValue placeholder="Select a school" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="kent">Kent Denver School</SelectItem>
+                <SelectItem value="custom">Custom Canvas URL</SelectItem>
+              </SelectContent>
+            </Select>
+            {school === "custom" && (
+              <Input
+                id="custom-url"
+                placeholder="https://your.school.instructure.com"
+                value={customUrl}
+                onChange={e => setCustomUrl(e.target.value)}
+                className="mt-2"
+              />
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="token">API Token</Label>
+            <Input id="token" value={token} onChange={e => setToken(e.target.value)} />
+            <p className="text-sm text-muted-foreground">
+              Log in to Canvas &gt; Account &gt; Settings &gt; New Access Token.
+            </p>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleImport} disabled={loading}>
+            Import
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@emotion/is-prop-valid": "latest",
+    "@emotion/is-prop-valid": "1.3.1",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
@@ -58,9 +58,9 @@
     "date-fns": "^4.1.0",
     "embla-carousel-react": "8.5.1",
     "framer-motion": "^12.12.1",
-    "html2canvas": "latest",
+    "html2canvas": "1.4.1",
     "input-otp": "1.4.1",
-    "jspdf": "latest",
+    "jspdf": "3.0.1",
     "lucide-react": "^0.454.0",
     "next": "^15.3.2",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
## Summary
- implement real Canvas API fetching on `/api/lms/[provider]`
- extend `LmsImportDialog` with school selection and custom Canvas URL option
- document Canvas token steps in README
- pin dependency versions for reproducible builds

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm test` *(fails: missing script)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to import course and assignment data directly from Canvas LMS into the grade calculator.
  - Introduced an import dialog for connecting to Canvas, supporting both predefined and custom school URLs.

- **Documentation**
  - Updated the README with step-by-step instructions for importing data from Canvas LMS.

- **Chores**
  - Pinned several package dependencies to specific versions for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->