### PR TITLE
Add Canvas LMS import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ Navigate to [http://localhost:3000](http://localhost:3000) to see the applicatio
 6. **Customize settings** in the settings tab to adjust display preferences
 7. **Export your data** to save your progress or share with others
 
+### Importing from Canvas
+
+1. Open the **Import from LMS** dialog and choose **Kent Denver School** or
+   select **Custom Canvas URL** to enter your own.
+2. To create an access token:
+   1. Log in to your Canvas account and open **Account → Settings**.
+   2. In **Approved Integrations** click **New Access Token**.
+   3. Give it a name and click **Generate Token**.
+   4. Copy the generated token.
+3. Paste the token into the dialog and click **Import** to load your classes and
+   assignments.
+
 ## 📊 Grade Calculation Logic
 
 The application uses the following formula to calculate the required score on a final exam:

--- a/app/api/lms/[provider]/route.ts
+++ b/app/api/lms/[provider]/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server"
+import type { GradeClass, Assignment } from "@/types/grade-calculator"
+
+export const runtime = "edge"
+
+function mapAssignment(a: any): Assignment {
+  return {
+    id: String(a.id ?? crypto.randomUUID()),
+    name: a.name || "Assignment",
+    score: a.submission?.score ?? 0,
+    totalPoints: a.points_possible ?? 100,
+    weight: 0,
+    date: a.due_at ?? undefined,
+  }
+}
+
+function mapClass(c: any): GradeClass {
+  return {
+    id: String(c.id ?? crypto.randomUUID()),
+    name: c.name || "Class",
+    current: c.grades?.current_score ?? c.currentGrade ?? 0,
+    weight: 0,
+    target: "A",
+    color: "bg-blue-500",
+    credits: c.credits,
+    assignments: Array.isArray(c.assignments) ? c.assignments.map(mapAssignment) : [],
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { provider: string } }
+) {
+  const { provider } = params
+  if (provider !== "canvas") {
+    return NextResponse.json({ error: "Unsupported provider" }, { status: 400 })
+  }
+
+  const { token, baseUrl } = await req.json().catch(() => ({}))
+  if (!token || !baseUrl) {
+    return NextResponse.json({ error: "Missing token or baseUrl" }, { status: 400 })
+  }
+
+  const headers = { Authorization: `Bearer ${token}` }
+
+  const coursesRes = await fetch(
+    `${baseUrl}/api/v1/courses?enrollment_state=active`,
+    { headers }
+  )
+  if (!coursesRes.ok) {
+    return NextResponse.json({ error: "Failed to fetch courses" }, { status: 400 })
+  }
+  const courses = await coursesRes.json()
+
+  const classes: GradeClass[] = []
+  for (const course of courses) {
+    const assignmentsRes = await fetch(
+      `${baseUrl}/api/v1/courses/${course.id}/assignments?per_page=100&include[]=submission`,
+      { headers }
+    )
+    const assignments = assignmentsRes.ok ? await assignmentsRes.json() : []
+    classes.push(mapClass({ ...course, assignments }))
+  }
+
+  return NextResponse.json({ classes })
+}

--- a/components/grade-calculator.tsx
+++ b/components/grade-calculator.tsx
@@ -58,6 +58,7 @@ import EnhancedWhatIf from "@/components/enhanced-what-if"
 import GradeStatistics from "@/components/grade-statistics"
 import { ExportDialog } from "@/components/export-dialog"
 import { ShareDialog } from "@/components/share-dialog"
+import { LmsImportDialog } from "@/components/lms-import-dialog"
 import { MobileOptimizations, TouchOptimizations } from "@/components/mobile-optimizations"
 import { useLocalStorage } from "@/hooks/use-local-storage"
 
@@ -234,6 +235,28 @@ export default function GradeCalculator() {
   const generateId = () => {
     return Math.random().toString(36).substring(2, 9)
   }
+
+  // Map data returned from the LMS API into the internal class format
+  const mapLmsClass = (cls: any): GradeClass => ({
+    id: generateId(),
+    name: cls.name || "Class",
+    current: cls.current ?? cls.currentGrade ?? 0,
+    weight: cls.weight ?? 100,
+    target: cls.target ?? "A",
+    color:
+      cls.color || colorOptions[Math.floor(Math.random() * colorOptions.length)].value,
+    credits: cls.credits,
+    assignments: Array.isArray(cls.assignments)
+      ? cls.assignments.map((a: any) => ({
+          id: generateId(),
+          name: a.name || "Assignment",
+          score: a.score ?? 0,
+          totalPoints: a.totalPoints ?? 100,
+          weight: a.weight ?? 0,
+          date: a.date || a.due,
+        }))
+      : [],
+  })
 
   const formatGrade = (grade: number): string => {
     return grade.toFixed(settings.showDecimalPlaces)
@@ -522,6 +545,11 @@ export default function GradeCalculator() {
 
     // Reset the input value so the same file can be imported again if needed
     event.target.value = ""
+  }
+
+  const importFromLms = (lmsClasses: any[]) => {
+    const mapped = lmsClasses.map(mapLmsClass)
+    setClasses([...classes, ...mapped])
   }
 
   const resetData = () => {
@@ -954,6 +982,9 @@ export default function GradeCalculator() {
                   Share
                 </Button>
               }
+            />
+            <LmsImportDialog
+              onImport={importFromLms}
             />
 
             <Button
@@ -1760,6 +1791,7 @@ export default function GradeCalculator() {
                     </Button>
                   }
                 />
+                <LmsImportDialog onImport={importFromLms} />
 
                 <Button
                   variant="outline"

--- a/components/lms-import-dialog.tsx
+++ b/components/lms-import-dialog.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { CloudDownload } from "lucide-react"
+import type { GradeClass } from "@/types/grade-calculator"
+import { useToast } from "@/hooks/use-toast"
+
+interface LmsImportDialogProps {
+  onImport: (classes: GradeClass[]) => void
+  trigger?: React.ReactNode
+}
+
+export function LmsImportDialog({ onImport, trigger }: LmsImportDialogProps) {
+  const { toast } = useToast()
+  const [open, setOpen] = useState(false)
+  const schools = [
+    { value: "kds", label: "Kent Denver School", url: "https://kentdenver.instructure.com" },
+    { value: "custom", label: "Custom Canvas URL" },
+  ]
+
+  const [school, setSchool] = useState<string>("kds")
+  const [baseUrl, setBaseUrl] = useState<string>(schools[0].url)
+  const [token, setToken] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const handleImport = async () => {
+    try {
+      setLoading(true)
+      const res = await fetch(`/api/lms/canvas`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, baseUrl }),
+      })
+      if (!res.ok) throw new Error("Request failed")
+      const data = await res.json()
+      if (Array.isArray(data.classes)) {
+        onImport(data.classes as GradeClass[])
+        toast({
+          title: "Import successful",
+          description: "Data imported from your LMS.",
+        })
+        setOpen(false)
+      } else {
+        throw new Error("Invalid response")
+      }
+    } catch (err) {
+      toast({
+        title: "Import failed",
+        description: "Unable to import data from LMS.",
+        variant: "destructive",
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger || (
+          <Button variant="outline" size="sm" className="hidden sm:flex">
+            <CloudDownload className="w-4 h-4 mr-1" />
+            Import from LMS
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Import from LMS</DialogTitle>
+          <DialogDescription>
+            Connect to your learning management system and import your classes.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4 space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="school">School</Label>
+            <Select value={school} onValueChange={(v) => {
+              setSchool(v)
+              if (v === "kds") setBaseUrl(schools[0].url)
+            }}>
+              <SelectTrigger id="school">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {schools.map((s) => (
+                  <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {school === "custom" && (
+            <div className="space-y-2">
+              <Label htmlFor="url">Canvas URL</Label>
+              <Input id="url" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} placeholder="https://school.instructure.com" />
+            </div>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="token">API Token</Label>
+            <Input id="token" value={token} onChange={e => setToken(e.target.value)} />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Generate a token in Canvas under <strong>Account → Settings → New Access Token</strong>.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleImport} disabled={loading}>
+            Import
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,7 +9,7 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
-  output: 'export',
+  output: 'standalone',
   reactStrictMode: true,
   compress: true,
   experimental: {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@emotion/is-prop-valid": "latest",
+    "@emotion/is-prop-valid": "1.3.1",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
@@ -58,9 +58,9 @@
     "date-fns": "^4.1.0",
     "embla-carousel-react": "8.5.1",
     "framer-motion": "^12.12.1",
-    "html2canvas": "latest",
+    "html2canvas": "1.4.1",
     "input-otp": "1.4.1",
-    "jspdf": "latest",
+    "jspdf": "3.0.1",
     "lucide-react": "^0.454.0",
     "next": "^15.3.2",
     "next-themes": "^0.4.6",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,4 +2,4 @@ name = "final-exam-grade-calculator"
 compatibility_date = "2023-06-01"
 
 # Configuration for Cloudflare Pages
-pages_build_output_dir = "out"
+pages_build_output_dir = ".vercel/output"


### PR DESCRIPTION
## Summary
- implement real Canvas API integration with edge runtime
- extend LMS import dialog with school selection and Canvas token instructions
- document Canvas import steps in README
- switch Next.js to standalone output and update Wrangler
- pin problematic dependencies

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm test` *(fails: missing script)*